### PR TITLE
rpc: use tirpc for rpc if libc doesn't provide rpc.h

### DIFF
--- a/Configure
+++ b/Configure
@@ -2945,8 +2945,14 @@ return(0); }
 
     # Test for <rpc/rpc.h>.
 
-    if ! test -r ${LSOF_INCLUDE}/rpc/rpc.h	# {
+    if test -r ${LSOF_INCLUDE}/rpc/rpc.h	# {
     then
+      :	# Do nothing
+    elif test -r ${LSOF_INCLUDE}/tirpc/rpc/rpc.h
+    then
+      LSOF_DINC="${LSOF_DINC} -I${LSOF_INCLUDE}/tirpc"
+      LSOF_CFGL="${LSOF_CFGL} -ltirpc"
+    else
       LSOF_CFGF="$LSOF_CFGF -DHASNORPC_H"
     fi	# }
 

--- a/dialects/linux/tests/case-20-inet-socket-endpoint.sh
+++ b/dialects/linux/tests/case-20-inet-socket-endpoint.sh
@@ -25,7 +25,7 @@ killBoth()
 } 2> /dev/null > /dev/null
 
 fclient=/tmp/${name}-client-$$
-$lsof -n -E -P -p $client > $fclient
+$lsof -M -n -E -P -p $client > $fclient
 if ! cat $fclient | grep -q "TCP 127.0.0.1:[0-9]\+->127.0.0.1:10000 -> $server,nc,[0-9]\+u (ESTABLISHED)"; then
     echo "failed in client side" >> $report
     cat $fclient >> $report
@@ -34,7 +34,7 @@ if ! cat $fclient | grep -q "TCP 127.0.0.1:[0-9]\+->127.0.0.1:10000 -> $server,n
 fi
 
 fserver=/tmp/${name}-server-$$
-$lsof -n -E -P -p $server > $fserver
+$lsof -M -n -E -P -p $server > $fserver
 if ! cat $fserver | grep -q "TCP 127.0.0.1:10000->127.0.0.1:[0-9]\+ -> $client,nc,[0-9]\+u (ESTABLISHED)"; then
     echo "failed in server side" >> $report
     cat $fserver >> $report


### PR DESCRIPTION
Close #10.

Check the existence of tirpc/rpc/rpc.h in Configure if rpc/rpc.h is
not available. For using tirpc implementation, LSOF_DINC and LSOF_CFGL
ad update if tirpc/rpc/rpc.h is found.

This change is based on Peter Schiffer <pschiffe@redhat.com>'s work
at Fedora.
https://src.fedoraproject.org/rpms/lsof/c/f1c2bfc28c74d1c2a2f4d3e4815b6c564b4388b3?branch=master

The original bug report is found at
https://bugzilla.redhat.com/show_bug.cgi?id=1574669

Signed-off-by: Masatake YAMATO <yamato@redhat.com>