### PR TITLE
Support POSIX message queue

### DIFF
--- a/dialects/linux/dlsof.h
+++ b/dialects/linux/dlsof.h
@@ -174,6 +174,7 @@ struct sfile {
 };
 
 extern int HasNFS;
+extern dev_t MqueueDev;
 extern int OffType;
 
 #endif	/* LINUX_LSOF_H	*/

--- a/dialects/linux/dmnt.c
+++ b/dialects/linux/dmnt.c
@@ -429,6 +429,7 @@ readmnt()
 	struct mounts *mp;
 	FILE *ms;
 	int nfs;
+	int mqueue;
 	struct stat sb;
 	static char *vbuf = (char *)NULL;
 	static size_t vsz = (size_t)0;
@@ -524,6 +525,12 @@ readmnt()
 	    if (*dn != '/')
 		continue;
 	    dnl = strlen(dn);
+
+	/*
+	 * Test Mqueue directory
+	 */
+	    mqueue = strcmp(fp[2], "mqueue");
+
 	/*
 	 * Test for duplicate and NFS directories.
 	 */
@@ -635,8 +642,12 @@ readmnt()
 		mp->ty = N_NFS;
 		if (HasNFS < 2)
 		    HasNFS = 2;
-	    } else
+	    } else if (!mqueue) {
+		mp->ty = N_MQUEUE;
+		MqueueDev = mp->dev;
+	    } else {
 		mp->ty = N_REGLR;
+	    }
 
 #if	defined(HASMNTSUP)
 	/*

--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -832,7 +832,10 @@ process_proc_node(p, pbr, s, ss, l, ls)
 		tn = "FIFO";
 		break;
 	    case S_IFREG:
-		tn = "REG";
+		if (Lf->dev == MqueueDev)
+		    tn = "PSXMQ";
+		else
+		    tn = "REG";
 		break;
 	    case S_IFLNK:
 		tn = "LINK";

--- a/dialects/linux/dstore.c
+++ b/dialects/linux/dstore.c
@@ -46,6 +46,8 @@ int HasNFS = 0;				/* NFS mount point status:
 					 *          and its device number is
 					 *          known
 					 */
+dev_t MqueueDev = -1;			/* The number for the device behind
+					 * mqueue mount point */
 int OffType = 0;			/* offset type:
 					 *     0 == unknown
 					 *     1 == lstat's st_size

--- a/dialects/linux/tests/GNUmakefile
+++ b/dialects/linux/tests/GNUmakefile
@@ -1,3 +1,18 @@
-HELPERS = target-open-with-flags
+HELPERS = \
+	mq-open \
+	target-open-with-flags \
+	\
+	$(NULL)
+
 CFLAGS  = -g -Wall -std=c99
+
 all: $(HELPERS)
+
+# See
+# https://stackoverflow.com/questions/19964206/weird-posix-message-queue-linking-issue-sometimes-it-doesnt-link-correctly
+#
+# We cannot use LDFLAGS here.
+# -lrt must be at the end of the command line.
+#
+mq-open: mq-open.o
+	$(CC) $(CFLAGS) -o $@ $< -lrt

--- a/dialects/linux/tests/case-20-mqueue.sh
+++ b/dialects/linux/tests/case-20-mqueue.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+MQUEUE_MNTPOINT=/tmp/$$
+
+TARGET=$tdir/mq-open
+if ! [ -x $TARGET ]; then
+    echo "target execution ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+if grep -q mqueue /proc/mounts; then
+    :
+elif ! [ $(id -u) = 0 ]; then
+    echo "root privileged is needed to run $(basename $0. sh)" >> $report
+    exit 2
+else
+    mkdir -p ${MQUEUE_MNTPOINT}
+    if ! mount -t mqueue none ${MQUEUE_MNTPOINT}; then
+	echo "failed to mount mqeueu file system"
+	exit 2
+    fi
+fi
+
+
+cleanup()
+{
+    status=$1
+    pid=$2
+
+    umount ${MQUEUE_MNTPOINT}
+    rmdir ${MQUEUE_MNTPOINT}
+    kill $pid
+    exit $status
+}
+
+$TARGET | {
+    if read label0 pid sep label1 fd; then
+	if line=`$lsof -p $pid -a -d $fd -Ft`; then
+	    if echo "$line" | grep -q PSXMQ; then
+		cleanup 0 $pid
+	    else
+		echo "unexpected output: $line" >> $report
+		cleanup 1 $pid
+	    fi
+	else
+	    echo "lsof rejects following command line: $lsof -p $pid -a -d $fd" >> $report
+	    cleanup 1 $pid
+	fi
+    else
+	echo "$TARGET prints an unexpected line: $label0 $pid $sep $label1 $fd" >> $report
+	case "$pid" in
+	    [0-9]*)
+		kill $pid
+		;;
+	esac
+	exit 1
+    fi
+}

--- a/dialects/linux/tests/mq-open.c
+++ b/dialects/linux/tests/mq-open.c
@@ -1,0 +1,23 @@
+#include <fcntl.h>           /* For O_* constants */
+#include <sys/stat.h>        /* For mode constants */
+#include <mqueue.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#define NAME "/xxx"
+
+int
+main(void)
+{
+  mqd_t t = mq_open(NAME, O_CREAT|O_RDWR, S_IRUSR|S_IWUSR, NULL);;
+  if ((mqd_t)t == -1)
+    {
+      perror("open[" NAME "]");
+      return 1;
+    }
+
+  printf("pid: %d / fd: %d\n", getpid(), t);
+  fflush(stdout);
+  pause();
+  return 0;
+}

--- a/lsof.1
+++ b/lsof.1
@@ -2725,6 +2725,8 @@ or ``PSTA'' for a
 .I /proc
 status file;
 .IP
+or ``PSXMQ'' for a POSIX message queue file;
+.IP
 or ``PSXSEM'' for a POSIX semaphore file;
 .IP
 or ``PSXSHM'' for a POSIX shared memory file;

--- a/lsof.h
+++ b/lsof.h
@@ -384,6 +384,7 @@ static struct utmp dummy_utmp;		/* to get login name length */
 #define	N_VXFS		52		/* Veritas file system node */
 #define	N_XFS		53		/* XFS node */
 #define	N_ZFS		54		/* ZFS node */
+#define	N_MQUEUE	55		/* Posix mqueue node on Linux */
 
 # if	!defined(OFFDECDIG)
 #define	OFFDECDIG	8		/* maximum number of digits in the


### PR DESCRIPTION
A file descriptor is used for implementing a POSIX message queue on
Linux. lsof reports the file descriptor as a REGular file.

This change introduce "PSXMQ" as a new file type for the
file descriptor.

Currently implementation requires mqueue file system must be
mounted to resolve the file type. It is mounted at /dev/mqueue
by default on Fedora. It seems that the file system is not mounted
by default on Ubuntu.
