### PR TITLE
endpoint(pipe),fix: list the same fd in a different process

### DIFF
--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -383,13 +383,15 @@ is_pty_ptmx(dev)
  */
 
 pxinfo_t *
-find_pepti(lf, pp)
+find_pepti(pid, lf, pp)
+	int pid;			/* pid of the process owning lf */
 	struct lfile *lf;		/* pipe's lfile */
 	pxinfo_t *pp;			/* previous pipe info (NULL == none) */
 {
 	struct lfile *ef;		/* pipe end local file structure */
 	int h;				/* hash result */
 	pxinfo_t *pi;			/* pipe info pointer */
+	struct lproc *ep;
 
 	if (Pinfo) {
 	    if (pp)
@@ -401,7 +403,8 @@ find_pepti(lf, pp)
 	    while (pi) {
 		if (pi->ino == lf->inode) {
 		    ef = pi->lf;
-		    if (strcmp(lf->fd, ef->fd))
+		    ep = &Lproc[pi->lpx];
+		    if ((strcmp(lf->fd, ef->fd)) || (pid != ep->pid))
 			return(pi);
 	 	}
 		pi = pi->next;

--- a/dialects/linux/tests/GNUmakefile
+++ b/dialects/linux/tests/GNUmakefile
@@ -1,5 +1,6 @@
 HELPERS = \
 	mq-open \
+	pipe \
 	target-open-with-flags \
 	\
 	$(NULL)
@@ -16,3 +17,6 @@ all: $(HELPERS)
 #
 mq-open: mq-open.o
 	$(CC) $(CFLAGS) -o $@ $< -lrt
+
+pipe: pipe.o
+	$(CC) $(CFLAGS) -o $@ $<

--- a/dialects/linux/tests/case-20-mqueue.sh
+++ b/dialects/linux/tests/case-20-mqueue.sh
@@ -9,7 +9,7 @@ MQUEUE_MNTPOINT=/tmp/$$
 
 TARGET=$tdir/mq-open
 if ! [ -x $TARGET ]; then
-    echo "target execution ( $TARGET ) is not found" >> $report
+    echo "target executable ( $TARGET ) is not found" >> $report
     exit 1
 fi
 

--- a/dialects/linux/tests/case-20-pipe-endpoint.sh
+++ b/dialects/linux/tests/case-20-pipe-endpoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+TARGET=$tdir/pipe
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+{ ./$TARGET & } | {
+    read parent child fdr fdw;
+    if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fdr" ] || [ -z "$fdw" ]; then
+	echo "unexpected output form target ( $TARGET )" >> $report
+	exit 1
+    fi
+    echo parent: $parent >> $report
+    echo child:  $child >> $report
+    echo fdr:    $fdr >> $report
+    echo fdw:    $fdw >> $report
+    echo cmdline: "$lsof +E -p "$parent"" >> $report
+    $lsof +E -p "$parent" >> $report
+
+    {
+	{
+	    echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe ${child},p[-a-z]*,${fdw}w"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $parent .* ${fdr}r *FIFO .* pipe ${child},p[-a-z]*,${fdw}w"
+	} && {
+	    echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r"
+	} && {
+	    exit 0
+	}
+    } >> $report
+}

--- a/dialects/linux/tests/case-20-pipe-no-close-endpoint.sh
+++ b/dialects/linux/tests/case-20-pipe-no-close-endpoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+TARGET=$tdir/pipe
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+{ ./$TARGET no-close & } | {
+    read parent child fdr fdw;
+    if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fdr" ] || [ -z "$fdw" ]; then
+	echo "unexpected output form target ( $TARGET )" >> $report
+	exit 1
+    fi
+    echo parent: $parent >> $report
+    echo child:  $child >> $report
+    echo fdr:    $fdr >> $report
+    echo fdw:    $fdw >> $report
+    echo cmdline: "$lsof +E -p "$parent"" >> $report
+    $lsof +E -p "$parent" >> $report
+
+    {
+	{
+	    # pipe-no-c 25113 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,4w 25114,pipe-no-c,3r 25114,pipe-no-c,4w
+	    echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $parent .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
+	} && {
+	    # pipe-no-c 25113 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25114,pipe-no-c,3r 25114,pipe-no-c,4w
+	    echo expected pattern: ".* $parent .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $parent .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
+	} && {
+	    # pipe-no-c 25114 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,4w
+	    echo expected pattern: ".* $child .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdw}w"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $child .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdw}w"
+	} && {
+	    # pipe-no-c 25114 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,3r
+	    echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r"
+	    $lsof +E -p "$parent" |
+		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r"
+	} && {
+	    exit 0
+	}
+    } >> $report
+}

--- a/dialects/linux/tests/pipe.c
+++ b/dialects/linux/tests/pipe.c
@@ -1,0 +1,47 @@
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+int
+main(int argc, char **argv)
+{
+  int no_close = 0;
+
+  if (argc > 1 && strcmp (argv[1], "no-close") == 0)
+    no_close = 1;
+
+  int pd[2];
+
+  if (pipe (pd) < 0)
+    {
+      perror("pipe");
+      return 1;
+    }
+
+  pid_t self, child;
+
+  self = getpid();
+  child = fork();
+
+  if (child == 0)
+    {
+      if (!no_close)
+	close (pd[0]);
+      pause ();
+      return 0;
+    }
+  else if (child < 0)
+    {
+      perror("fork");
+      return 1;
+    }
+
+  if (!no_close)
+    close (pd[1]);
+  printf("%d %d %d %d\n", self, child, pd[0], pd[1]);
+  fflush(stdout);
+  wait (NULL);
+  return 0;
+}

--- a/proc.c
+++ b/proc.c
@@ -1001,7 +1001,7 @@ process_pinfo(f)
 		 * its being a pipe.  Look up the pipe's endpoints.
 		 */
 		    do {
-			if ((pp = find_pepti(Lf, pp))) {
+			if ((pp = find_pepti(Lp->pid, Lf, pp))) {
 
 			/*
 			 * This pipe endpoint is linked to the selected pipe
@@ -1042,7 +1042,7 @@ process_pinfo(f)
 		    Lf->sf = Selflags;
 		    Lp->pss |= PS_SEC;
 		    do {
-			if ((pp = find_pepti(Lf, pp))) {
+			if ((pp = find_pepti(Lp->pid, Lf, pp))) {
 			    ep = &Lproc[pp->lpx];
 			    ef = pp->lf;
 			    for (i = 0; i < (FDLEN - 1); i++) {

--- a/proto.h
+++ b/proto.h
@@ -112,7 +112,7 @@ _PROTOTYPE(extern void find_ch_ino,(void));
 
 # if	defined(HASEPTOPTS)
 _PROTOTYPE(extern void clear_pinfo,(void));
-_PROTOTYPE(extern pxinfo_t *find_pepti,(struct lfile *lf, pxinfo_t *pp));
+_PROTOTYPE(extern pxinfo_t *find_pepti,(int pid, struct lfile *lf, pxinfo_t *pp));
 _PROTOTYPE(extern void process_pinfo,(int f));
 #  if	defined(HASUXSOCKEPT)
 _PROTOTYPE(extern void clear_uxsinfo,(void));


### PR DESCRIPTION
 +|-E option should not print a fd as an endpoint for the fd.
Consider following a bit odd example code:

  int pd[2];
  pipe(pd);
  fork();

4 file descriptors appear in this case: the parent's read and write
endpoints(fd0, fd1), and the child's read and write endpoints(fd2, fd3).

For fd0, lsof +|-E should print fd1, fd2, and fd3 as the endpoints.
However, the original code only prints fd1 and fd3 because of a bug.

fd0 (in the parent process) and fd2 (in the child process) have the
same integer value. The original code compares only the integer value
to avoid printing fd0 as the endpoint for fd0. With the logic, fd2 is
never printed.

This commit checks both the integer value and process identifiers for
the file descriptors. fd0 and fd2 have the same integer value, however
the owner processes are not the same. The new logic can distinguish
the two file descriptors.
