### PR TITLE
endpoint(pty),bug fix: list the same fd in a different process

### DIFF
--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -307,7 +307,8 @@ enter_ptmxi(mn)
  */
 
 pxinfo_t *
-find_ptyepti(lf, m, pp)
+find_ptyepti(pid, lf, m, pp)
+	int pid;
 	struct lfile *lf;		/* pseudoterminal's lfile */
 	int m;				/* minor number type:
 					 *     0 == use tty_index
@@ -319,6 +320,7 @@ find_ptyepti(lf, m, pp)
 	int h;				/* hash result */
 	INODETYPE mn;			/* minor number */
 	pxinfo_t *pi;			/* pseudoterminal info pointer */
+	struct lproc *ep;
 
 
 	mn = m ? GET_MIN_DEV(lf->rdev) : lf->tty_index;
@@ -332,12 +334,10 @@ find_ptyepti(lf, m, pp)
 	    while (pi) {
 		if (pi->ino == mn) {
 		    ef = pi->lf;
-		    if (((m && is_pty_ptmx(ef->rdev))
+		    ep = &Lproc[pi->lpx];
+		    if ((m && is_pty_ptmx(ef->rdev))
 		    ||  ((!m) && is_pty_slave(GET_MAJ_DEV(ef->rdev))))
-		    &&   strcmp(lf->fd, ef->fd)
-		    ) {
 			return(pi);
-		    }
 		}
 		pi = pi->next;
 	     }

--- a/dialects/linux/tests/GNUmakefile
+++ b/dialects/linux/tests/GNUmakefile
@@ -1,6 +1,7 @@
 HELPERS = \
 	mq-open \
 	pipe \
+	pty \
 	target-open-with-flags \
 	\
 	$(NULL)
@@ -19,4 +20,7 @@ mq-open: mq-open.o
 	$(CC) $(CFLAGS) -o $@ $< -lrt
 
 pipe: pipe.o
+	$(CC) $(CFLAGS) -o $@ $<
+
+pty: pty.o
 	$(CC) $(CFLAGS) -o $@ $<

--- a/dialects/linux/tests/case-20-pipe-endpoint.sh
+++ b/dialects/linux/tests/case-20-pipe-endpoint.sh
@@ -34,7 +34,10 @@ fi
 	    $lsof +E -p "$parent" |
 		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r"
 	} && {
+	    kill "$child"
 	    exit 0
 	}
     } >> $report
+    kill "$child"
+    exit 1
 }

--- a/dialects/linux/tests/case-20-pipe-no-close-endpoint.sh
+++ b/dialects/linux/tests/case-20-pipe-no-close-endpoint.sh
@@ -46,7 +46,10 @@ fi
 	    $lsof +E -p "$parent" |
 		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r"
 	} && {
+	    kill $child
 	    exit 0
 	}
     } >> $report
+    kill $child
+    exit 1
 }

--- a/dialects/linux/tests/case-20-pty-endpoint.sh
+++ b/dialects/linux/tests/case-20-pty-endpoint.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+uname -r >> $report
+uname -r | sed -ne 's/^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/\1 \2/p' | {
+    read major minor
+    if [ "$major" -lt 4 ]; then
+	echo "pty endpoint features doesn't work on Linux $major"
+	exit 2
+    fi
+    if [ "$minor" -lt 13 ]; then
+	echo "pty endpoint features doesn't work on Linux $major.$minor"
+	exit 2
+    fi
+} >> $report
+s=$?
+if ! [ $s = 0 ]; then
+    exit $s
+fi
+
+TARGET=$tdir/pty
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+{ ./$TARGET & } | {
+    read parent child fdm fds names;
+    if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fdm" ] || [ -z "$fds" ] || [ -z "$names" ]; then
+	echo "unexpected output form target ( $TARGET )" >> $report
+	exit 1
+    fi
+    {
+	echo parent: $parent
+	echo child:  $child
+	echo fdm:    $fdm
+	echo fds:    $fds
+	echo nams:   $names
+	echo cmdline: "$lsof +E -p $parent"
+    } >> $report
+    $lsof +E -p "$parent" >> $report
+    {
+	{
+	    # pty     17592 yamato    3r   CHR    5,2      0t0       1129 /dev/ptmx ->/dev/pts/16 17592,pty,4r 17593,pty,3r
+	    echo expected pattern: "pty *$parent .* ${fdm}r *CHR .* /dev/ptmx ->/dev/pts/$names ($parent,pty,${fds}r $child,pty,${fdm}r)|($child,pty,${fdm}r $parent,pty,${fds}r)"
+	    $lsof +E -p "$parent" |
+		grep -E -q "pty *$parent .* ${fdm}r *CHR .* /dev/ptmx ->/dev/pts/$names ($parent,pty,${fds}r $child,pty,${fdm}r)|($child,pty,${fdm}r $parent,pty,${fds}r)"
+	} && {
+	    # pty     17592 yamato    4r   CHR 136,16      0t0         19 /dev/pts/16 17592,pty,3r
+	    echo expected pattern: "pty *$parent .* ${fds}r *CHR .* /dev/pts/$names $parent,pty,${fdm}r"
+	    $lsof +E -p "$parent" |
+		grep -E -q "pty *$parent .* ${fds}r *CHR .* /dev/pts/$names $parent,pty,${fdm}r"
+	} && {
+	    # pty     17593 yamato    3r   CHR 136,16      0t0         19 /dev/pts/16 17592,pty,3r
+	    echo expected pattern: "pty *$child .* ${fdm}r *CHR .* /dev/pts/$names $parent,pty,${fdm}r"
+	    $lsof +E -p "$parent" |
+		grep -E -q "pty *$child .* ${fdm}r *CHR .* /dev/pts/$names $parent,pty,${fdm}r"
+	} && {
+	    kill "$child"
+	    exit 0
+	}
+    } >> $report
+    kill "$child"
+    exit 1
+}

--- a/dialects/linux/tests/pty.c
+++ b/dialects/linux/tests/pty.c
@@ -1,0 +1,52 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <error.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+int
+main(void)
+{
+  int tfd[2];
+  int s;
+
+  if ((tfd[0] = open("/dev/ptmx", O_RDONLY)) < 0)
+    error (1, errno, "failed to open ptmx");
+
+  int unlock = 0;
+  if (ioctl(tfd[0], TIOCSPTLCK, &unlock) < 0)
+    error (1, errno, "failed to do ioctl TIOCSPTLCK");
+
+  if (ioctl(tfd[0], TIOCGPTN, &s) < 0)
+    error (1, errno, "failed to do ioctl TIOCGPTN");
+
+  char slave_name [128];
+  snprintf(slave_name, 128, "/dev/pts/%d", s);
+  if ((tfd[1] = open(slave_name, O_RDONLY)) < 0)
+    error (1, errno, "failed to open %s", slave_name);
+
+  pid_t self, child;
+  self = getpid();
+  child = fork();
+
+  if (child == 0)
+    {
+      if (dup2(tfd[1], tfd[0]) < 0)
+	error (1, errno, "failed to dup2(%d, %d)", tfd[1], tfd[0]);
+      close (tfd[1]);
+      pause();
+      return 0;
+    }
+  else if (child < 0)
+    {
+      perror("fork");
+      return 1;
+    }
+
+  printf("%d %d %d %d %d\n", self, child, tfd[0], tfd[1], s);
+  fflush(stdout);
+  wait (NULL);
+  return 0;
+}

--- a/lsof.1
+++ b/lsof.1
@@ -676,7 +676,7 @@ are the same as with pipe endpoint information.
 Note: psudoterminal endpoint information is only available when the compile
 flags line of
 .B \-V
-output contains HASPTYEPT.
+output contains HASPTYEPT. In addition, this feature works on Linux kernels above 4.13.0.
 .IP
 UNIX socket file endpoint information is displayed in the NAME column
 in the form

--- a/proc.c
+++ b/proc.c
@@ -1452,7 +1452,7 @@ process_ptyinfo(f)
 		 */
 		    pc = 1;
 		    do {
-			if ((pp = find_ptyepti(Lf, !mos, pp))) {
+			if ((pp = find_ptyepti(Lp->pid, Lf, !mos, pp))) {
 
 			/*
 			 * This pseudoterminal endpoint is linked to the
@@ -1477,7 +1477,7 @@ process_ptyinfo(f)
 		    Lp->pss |= PS_SEC;
 		    pc = 1;
 		    do {
-			if ((pp = find_ptyepti(Lf, !mos, pp))) {
+			if ((pp = find_ptyepti(Lp->pid, Lf, !mos, pp))) {
 			    prt_ptyinfo(pp, (mos && pc), 0);
 			    pp = pp->next;
 			    pc = 0;

--- a/proto.h
+++ b/proto.h
@@ -122,7 +122,7 @@ _PROTOTYPE(extern void process_uxsinfo,(int f));
 #  if	defined(HASPTYEPT)
 _PROTOTYPE(extern void clear_ptyinfo,(void));
 _PROTOTYPE(extern void enter_ptmxi,(int mn));
-_PROTOTYPE(extern pxinfo_t *find_ptyepti,(struct lfile *lf,int m,pxinfo_t *pp));
+_PROTOTYPE(extern pxinfo_t *find_ptyepti,(int pid, struct lfile *lf,int m,pxinfo_t *pp));
 _PROTOTYPE(extern int is_pty_slave,(int sm));
 _PROTOTYPE(extern int is_pty_ptmx,(dev_t dev));
 _PROTOTYPE(extern void process_ptyinfo,(int f));


### PR DESCRIPTION
 
This change is simillar to 28f96d5 (endpoint(pipe),fix: list the same
fd in a different process).  28f96d5 is about pipe. This change is
about pty.

A test case is added, too.
lsof.1 man page is updated, too: write about the required kernel version.
