### PR TITLE
testcase(endpoint(inet)): remove unnecessary "->" in inet endpoint ou…

### DIFF
--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -1358,11 +1358,6 @@ prt_nets(p, mk)
 	char nma[1024];			/* character buffer */
 	pxinfo_t *pp;			/* previous pipe info of socket */
 
-	if (p->pxinfo) {
-	    (void) strcpy(nma, "->");
-	    (void) add_nma(nma, strlen(nma));
-	}
-
 	for (pp = p->pxinfo; pp; pp = pp->next) {
 
 	/*

--- a/dialects/linux/tests/case-20-inet-socket-endpoint.sh
+++ b/dialects/linux/tests/case-20-inet-socket-endpoint.sh
@@ -26,7 +26,7 @@ killBoth()
 
 fclient=/tmp/${name}-client-$$
 $lsof -M -n -E -P -p $client > $fclient
-if ! cat $fclient | grep -q "TCP 127.0.0.2:9999->127.0.0.1:10000 -> $server,nc,[0-9]\+u (ESTABLISHED)"; then
+if ! cat $fclient | grep -q "TCP 127.0.0.2:9999->127.0.0.1:10000 $server,nc,[0-9]\+u (ESTABLISHED)"; then
     echo "failed in client side" >> $report
     cat $fclient >> $report
     killBoth $client $server
@@ -35,7 +35,7 @@ fi
 
 fserver=/tmp/${name}-server-$$
 $lsof -M -n -E -P -p $server > $fserver
-if ! cat $fserver | grep -q "TCP 127.0.0.1:10000->127.0.0.2:9999\+ -> $client,nc,[0-9]\+u (ESTABLISHED)"; then
+if ! cat $fserver | grep -q "TCP 127.0.0.1:10000->127.0.0.2:9999\+ $client,nc,[0-9]\+u (ESTABLISHED)"; then
     echo "failed in server side" >> $report
     cat $fserver >> $report
     killBoth $client $server


### PR DESCRIPTION
…tput

Like pipe endpoint, "->" should not be used here.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>